### PR TITLE
build: bump abseil pin for Clang >= 21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,10 @@ find_package(LAPACK REQUIRED)
 FetchContent_Declare(
   abseil-cpp
   GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-  GIT_TAG 4447c7562e3bc702ade25105912dce503f0c4010
+  # 20260107.1 LTS: required for Clang >= 21, where the 2024 pin fails to
+  # compile (absl::Nonnull SFINAE in absl/strings/ascii.cc). Clang is the
+  # compiler used for the Enzyme autodiff build.
+  GIT_TAG 20260107.1
   GIT_SHALLOW TRUE
 )
 FetchContent_Declare(


### PR DESCRIPTION
## What

Bump the CMake `FetchContent` abseil pin from the 2024-08 commit to the
`20260107.1` LTS tag.

## Why

The differentiable VMEC++ work (Enzyme autodiff) requires Clang, since the
ClangEnzyme plugin only attaches to a Clang frontend. The 2024 abseil pin does
not compile under Clang >= 21:

- `absl/strings/ascii.cc` uses `absl::Nonnull`, whose `EnableNonnull` SFINAE the
  Clang 21 frontend rejects.
- `absl/strings/numbers.cc` then fails with nullability-annotated out-of-line
  definitions that no longer match their declarations.

`20260107.1` compiles cleanly under both Clang 21.1.8 and GCC. This is the same
abseil release nixpkgs builds against its Clang 21 toolchain. The newest tag
(`20260526.0`) was rejected: it reintroduces the `numbers.cc` mismatch under
Clang 21, so this pin deliberately stops at `20260107.1`.

This is the first patch in a stack that adds an Enzyme-based differentiable build
of VMEC++. It changes only the CMake dependency pin; no source changes.

The Bazel build keeps its own abseil version from the Bazel Central Registry and
is untouched.

## Verification

All builds: `CMAKE_BUILD_TYPE=Release`, `-DVMECPP_USE_FFTX=OFF`, target
`vmec_standalone`.

Before, Clang 21.1.8, old pin:

```
absl/strings/ascii.cc:183:11: error: no member named 'Nonnull' in namespace 'absl'
absl/strings/numbers.cc:413:38: error: out-of-line definition of
    'RoundTripDoubleToBuffer' does not match any declaration in namespace
    'absl::numbers_internal'
ninja: build stopped: subcommand failed.
```

After, this pin:

```
Clang 21.1.8:  build=0 (0 errors)   [221/221] Linking CXX executable vmec_standalone
GCC 16.1.1:    EXIT=0 errors=0      [221/221] Linking CXX executable vmec_standalone
```

No numerical regression. `vmec_standalone examples/data/solovev.json`, final
multigrid step:

```
GCC (baseline):  MHD Energy = 2.548352e+00
Clang 21:        MHD Energy = 2.548352e+00
```
