### PR TITLE
enzyme: opt-in Clang/Enzyme build option + AD smoke test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,3 +175,34 @@ endif()
 
 install(TARGETS _vmecpp LIBRARY DESTINATION vmecpp/cpp/.)
 install(TARGETS indata2json DESTINATION vmecpp/cpp/third_party/indata2json/)
+
+# Optional Enzyme automatic-differentiation targets.
+# Enzyme (https://enzyme.mit.edu) differentiates LLVM IR via a Clang plugin, so
+# these targets need a Clang frontend and the matching ClangEnzyme plugin. OFF
+# by default; the production build and all existing targets are unaffected.
+# Enable with:
+#   -DVMECPP_ENABLE_ENZYME=ON -DVMECPP_ENZYME_PLUGIN=/path/to/ClangEnzyme-NN.so
+option(VMECPP_ENABLE_ENZYME "Build Enzyme autodiff targets" OFF)
+if(VMECPP_ENABLE_ENZYME)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR
+      "VMECPP_ENABLE_ENZYME requires a Clang compiler (got "
+      "${CMAKE_CXX_COMPILER_ID}); Enzyme attaches as a Clang plugin.")
+  endif()
+  set(VMECPP_ENZYME_PLUGIN "" CACHE FILEPATH "Path to ClangEnzyme-NN.so")
+  if(NOT VMECPP_ENZYME_PLUGIN OR NOT EXISTS "${VMECPP_ENZYME_PLUGIN}")
+    message(FATAL_ERROR
+      "VMECPP_ENABLE_ENZYME=ON requires "
+      "-DVMECPP_ENZYME_PLUGIN=/path/to/ClangEnzyme-NN.so")
+  endif()
+  message(STATUS "Enzyme plugin: ${VMECPP_ENZYME_PLUGIN}")
+  enable_testing()
+  add_executable(enzyme_smoke_test
+    ${PROJECT_SOURCE_DIR}/src/vmecpp/cpp/vmecpp/common/enzyme/enzyme_smoke_test.cc)
+  # Enzyme runs as an optimization-time pass; it needs optimizations enabled and
+  # the plugin attached. -O2 guards against a Debug (-O0) configuration where the
+  # AD pass would otherwise not run.
+  target_compile_options(enzyme_smoke_test PRIVATE
+    -O2 -fplugin=${VMECPP_ENZYME_PLUGIN})
+  add_test(NAME enzyme_smoke COMMAND enzyme_smoke_test)
+endif()

--- a/src/vmecpp/cpp/vmecpp/common/enzyme/enzyme.h
+++ b/src/vmecpp/cpp/vmecpp/common/enzyme/enzyme.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+#ifndef VMECPP_COMMON_ENZYME_ENZYME_H_
+#define VMECPP_COMMON_ENZYME_ENZYME_H_
+
+// Thin declarations for the Enzyme automatic-differentiation intrinsics.
+//
+// Enzyme (https://enzyme.mit.edu) differentiates at the LLVM-IR level via a
+// Clang plugin (ClangEnzyme-NN.so). These intrinsics are resolved by that
+// plugin; without it the symbols do not link, so any translation unit that
+// calls them must be compiled with -fplugin=<ClangEnzyme>. The CMake option
+// VMECPP_ENABLE_ENZYME wires that flag and is OFF by default.
+//
+// Differentiation activity is selected per argument with the marker globals
+// below: pass `enzyme_dup, primal_ptr, shadow_ptr` for an active buffer (the
+// gradient accumulates into shadow_ptr) and `enzyme_const, value` for an input
+// held fixed. Enzyme matches these markers by symbol name.
+//
+// Constraint that shapes how differentiable kernels here are written: Enzyme's
+// allocation analysis does not track Eigen's aligned allocator, so a heap
+// temporary from an Eigen expression (e.g. a dynamic-size `A * x`) crossing the
+// differentiated call aborts with "freeing without malloc". Differentiable
+// kernels therefore operate on caller-owned buffers via Eigen::Map and avoid
+// allocating expression temporaries on the differentiated path.
+
+// The marker globals and the __enzyme_* intrinsic names are part of the Enzyme
+// ABI: the plugin matches them by exact symbol name, so they cannot be const or
+// renamed to satisfy the in-tree naming/identifier lint rules.
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+extern int enzyme_dup;
+extern int enzyme_const;
+extern int enzyme_dupnoneed;
+extern int enzyme_out;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Reverse mode: returns nothing useful here; gradients land in the shadow
+// buffers passed alongside each `enzyme_dup` argument.
+template <typename... Args>
+void __enzyme_autodiff(  // NOLINT(bugprone-reserved-identifier,readability-identifier-naming)
+    void*, Args...);
+
+// Forward mode: propagates the seed in the shadow argument to the directional
+// derivative of the result.
+template <typename Return, typename... Args>
+Return
+__enzyme_fwddiff(  // NOLINT(bugprone-reserved-identifier,readability-identifier-naming)
+    void*, Args...);
+
+#endif  // VMECPP_COMMON_ENZYME_ENZYME_H_

--- a/src/vmecpp/cpp/vmecpp/common/enzyme/enzyme_smoke_test.cc
+++ b/src/vmecpp/cpp/vmecpp/common/enzyme/enzyme_smoke_test.cc
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2024-present Proxima Fusion GmbH
+// <info@proximafusion.com>
+//
+// SPDX-License-Identifier: MIT
+
+// Toolchain smoke test for the Enzyme autodiff build.
+//
+// It checks the two properties the differentiable VMEC++ kernels rely on:
+//   1. The ClangEnzyme plugin is attached and resolves the autodiff intrinsics.
+//   2. Enzyme differentiates a scalar objective expressed over Eigen::Map'd
+//      caller buffers (the pattern all differentiable kernels here use).
+//
+// The objective is f(x) = sum_i 0.5 * w_i * x_i^2 + c_i * x_i, with the closed
+// form gradient df/dx_i = w_i * x_i + c_i. Reverse- and forward-mode Enzyme
+// gradients are checked against that closed form and against central finite
+// differences. Exit code 0 on success, 1 on any mismatch.
+
+#include <Eigen/Dense>
+#include <cmath>
+#include <cstdio>
+
+#include "vmecpp/common/enzyme/enzyme.h"
+
+namespace {
+
+using Eigen::VectorXd;
+
+// Quadratic objective over caller-owned buffers. No allocating Eigen
+// expression temporaries cross the differentiated boundary.
+__attribute__((noinline)) double Objective(const double* x, const double* w,
+                                           const double* c, int n) {
+  Eigen::Map<const VectorXd> xv(x, n);
+  Eigen::Map<const VectorXd> wv(w, n);
+  Eigen::Map<const VectorXd> cv(c, n);
+  double sum = 0.0;
+  for (int i = 0; i < n; ++i) {
+    sum += 0.5 * wv[i] * xv[i] * xv[i] + cv[i] * xv[i];
+  }
+  return sum;
+}
+
+double MaxAbsDiff(const VectorXd& a, const VectorXd& b) {
+  return (a - b).cwiseAbs().maxCoeff();
+}
+
+}  // namespace
+
+int main() {
+  const int n = 8;
+  VectorXd x = VectorXd::LinSpaced(n, 1.0, n);
+  VectorXd w = VectorXd::LinSpaced(n, 2.0, 2.0 + 0.5 * (n - 1));
+  VectorXd c = VectorXd::Constant(n, 0.25);
+
+  VectorXd analytic(n);
+  for (int i = 0; i < n; ++i) analytic[i] = w[i] * x[i] + c[i];
+
+  // Reverse mode: gradient accumulates into the shadow buffer.
+  VectorXd g_rev = VectorXd::Zero(n);
+  __enzyme_autodiff((void*)Objective, enzyme_dup, x.data(), g_rev.data(),
+                    enzyme_const, w.data(), enzyme_const, c.data(),
+                    enzyme_const, n);
+
+  // Forward mode: one directional derivative per coordinate seed.
+  VectorXd g_fwd = VectorXd::Zero(n);
+  for (int j = 0; j < n; ++j) {
+    VectorXd seed = VectorXd::Zero(n);
+    seed[j] = 1.0;
+    g_fwd[j] = __enzyme_fwddiff<double>(
+        (void*)Objective, enzyme_dup, x.data(), seed.data(), enzyme_const,
+        w.data(), enzyme_const, c.data(), enzyme_const, n);
+  }
+
+  // Central finite differences.
+  VectorXd g_fd = VectorXd::Zero(n);
+  const double h = 1e-6;
+  for (int j = 0; j < n; ++j) {
+    VectorXd xp = x, xm = x;
+    xp[j] += h;
+    xm[j] -= h;
+    g_fd[j] = (Objective(xp.data(), w.data(), c.data(), n) -
+               Objective(xm.data(), w.data(), c.data(), n)) /
+              (2.0 * h);
+  }
+
+  const double err_rev = MaxAbsDiff(g_rev, analytic);
+  const double err_fwd = MaxAbsDiff(g_fwd, analytic);
+  const double err_fd = MaxAbsDiff(g_rev, g_fd);
+
+  std::printf("enzyme smoke test (n=%d)\n", n);
+  std::printf("  max|reverse - analytic| = %.3e\n", err_rev);
+  std::printf("  max|forward - analytic| = %.3e\n", err_fwd);
+  std::printf("  max|reverse - finite-diff| = %.3e\n", err_fd);
+
+  const bool ok = err_rev < 1e-10 && err_fwd < 1e-10 && err_fd < 1e-5;
+  std::printf("%s\n", ok ? "PASS" : "FAIL");
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## What

Add an opt-in Clang/Enzyme build path and a toolchain smoke test:

- `VMECPP_ENABLE_ENZYME` CMake option, **off by default**. When on, it requires
  a Clang compiler and `-DVMECPP_ENZYME_PLUGIN=/path/to/ClangEnzyme-NN.so`, and
  builds the `enzyme_smoke` test target.
- `common/enzyme/enzyme.h`: thin declarations of the Enzyme autodiff intrinsics
  and the activity markers, with the allocation constraint that shapes every
  differentiable kernel in this stack documented in place.
- `common/enzyme/enzyme_smoke_test.cc`: differentiates a scalar objective over
  `Eigen::Map`'d caller buffers and checks reverse- and forward-mode gradients
  against the closed form and central finite differences.

## Why

Stacked on #5. Enzyme differentiates LLVM IR through a Clang plugin, so the
differentiable VMEC++ work needs a Clang build and a way to attach the plugin.
This patch adds that switch and a test that fails loudly if the plugin is not
attached or if Enzyme cannot differentiate the `Eigen::Map` buffer pattern the
later kernels depend on. It adds no production code; with the option off, the
build is byte-for-byte the previous one.

The smoke test also pins down the one hard Enzyme constraint for this codebase:
Enzyme's allocation analysis does not track Eigen's aligned allocator, so a
dynamic-size Eigen heap temporary crossing the differentiated call aborts with
"freeing without malloc". Differentiable kernels therefore operate on
caller-owned buffers via `Eigen::Map`. The test exercises exactly that pattern.

## Verification

Configure and build with Clang 21.1.8 and the ClangEnzyme-21 plugin:

```
-- Enzyme plugin: .../ClangEnzyme-21.so
cfg=0
build=0 (0 errors)
```

`ctest`:

```
    Start 1: enzyme_smoke
1/1 Test #1: enzyme_smoke .....................   Passed    0.00 sec
100% tests passed, 0 tests failed out of 1
```

Smoke test output (reverse and forward both exact, agree with finite
differences):

```
enzyme smoke test (n=8)
  max|reverse - analytic| = 0.000e+00
  max|forward - analytic| = 0.000e+00
  max|reverse - finite-diff| = 2.646e-08
PASS
```

No regression with the option off. A default configure (GCC, no Enzyme flags)
succeeds and emits no `enzyme_smoke` target:

```
cfg=0  enzyme target present? 0
```
